### PR TITLE
Feature/firebase auth

### DIFF
--- a/code_documentation/auth_service.md
+++ b/code_documentation/auth_service.md
@@ -1,0 +1,81 @@
+# AuthService Detailed Documentation
+
+`AuthService` provides authentication and user management using Firebase Authentication and Firestore.
+
+## Features
+- Register new users with email, password, and optional username
+- Sign in users with email and password
+- Send password reset emails
+- Sign out users
+- Listen to authentication state changes
+- Create user profile documents in Firestore
+
+## API
+
+### Methods
+
+#### `Future<User?> signIn(String email, String password)`
+Signs in a user using Firebase Authentication.
+- **Parameters:**
+  - `email`: User's email address
+  - `password`: User's password
+- **Returns:**
+  - The signed-in `User` object, or `null` if sign-in fails
+
+#### `Future<User?> register(String email, String password, {String? username})`
+Registers a new user and creates a profile document in Firestore.
+- **Parameters:**
+  - `email`: User's email address
+  - `password`: User's password
+  - `username`: Optional display name
+- **Returns:**
+  - The created `User` object, or `null` if registration fails
+- **Firestore:**
+  - Creates a document in the `users` collection with the user's UID
+  - Document fields:
+    - `profile`: `{ displayName, age }`
+    - `stats`: `{ totalGamesPlayed, totalPoints, currentStreak, lastPlayedAt }`
+    - `settings`: `{}`
+
+#### `Future<void> sendPasswordReset(String email)`
+Sends a password reset email to the specified address.
+- **Parameters:**
+  - `email`: User's email address
+
+#### `Future<void> signOut()`
+Signs out the current user.
+
+#### `Stream<User?> get onAuthStateChanged`
+Stream that emits the current user or `null` when the authentication state changes.
+- Use this to react to login/logout events in your app.
+
+## Usage Example
+```dart
+final authService = AuthService();
+
+// Register a new user
+final user = await authService.register('email@example.com', 'password123', username: 'John');
+
+// Sign in
+final user = await authService.signIn('email@example.com', 'password123');
+
+// Listen to auth state changes
+authService.onAuthStateChanged.listen((user) {
+  if (user != null) {
+    print('User is signed in: ${user.email}');
+  } else {
+    print('User is signed out');
+  }
+});
+
+// Send password reset
+await authService.sendPasswordReset('email@example.com');
+
+// Sign out
+await authService.signOut();
+```
+
+## Notes
+- Firestore document is created in the `users` collection with the user's UID as the document ID.
+- Make sure your Firestore security rules allow authenticated users to write to the `users` collection.
+- All methods are asynchronous and should be awaited.

--- a/code_documentation/firebase_db_structure.md
+++ b/code_documentation/firebase_db_structure.md
@@ -1,0 +1,89 @@
+# Firebase Authentication & Firestore Database Structure
+
+## 1. Authentication
+- Managed by Firebase Authentication
+- User signs in with email and password
+- UID is generated and used as the primary user identifier
+
+## 2. Firestore Database Structure
+
+```
+Firestore Database
+│
+├── users/
+│   ├── {uid}/
+│   │   ├── profile: { displayName, age }
+│   │   ├── stats: { totalGamesPlayed, totalPoints, currentStreak, lastPlayedAt }
+│   │   ├── settings: { ... }
+│   │   └── (subcollection) levelProgress/
+│   │       ├── {levelId}/
+│   │       │   ├── levelId
+│   │       │   ├── bestScore
+│   │       │   ├── bestTimeSeconds
+│   │       │   ├── attempts
+│   │       │   ├── completed
+│   │       │   ├── firstCompletedAt
+│   │       │   └── lastPlayedAt
+│   │       └── ...
+│   └── ...
+│
+├── levels/
+│   ├── {levelId}/
+│   │   ├── levelNumber
+│   │   ├── name
+│   │   ├── description
+│   │   ├── unlockRequirements: { minPoints, previousLevelId }
+│   │   ├── rewards: { points }
+│   │   └── isRevision
+│   └── ...
+│
+└── leaderboards/
+    ├── global/
+    │   ├── entries[]: [ { playerId, playerName, streak, dateAchieved } ]
+    │   └── lastUpdated
+    └── level_{levelId}/
+        ├── entries[]: [ { playerId, playerName, streak, dateAchieved } ]
+        └── lastUpdated
+```
+
+## 3. Zasady
+- Po rejestracji użytkownika (email+hasło) tworzony jest dokument users/{uid}.
+- Stan zalogowania wynika wyłącznie z Firebase Auth (onAuthStateChanged).
+- Hive/local storage NIE przechowuje stanu zalogowania.
+- Hive może przechowywać cache/profil/postęp, ale nie decyduje o auth/routingu.
+
+## 4. Minimalny dokument użytkownika (users/{uid})
+```json
+{
+  "profile": {
+    "displayName": "Jan Kowalski",
+    "age": 20
+  },
+  "stats": {
+    "totalGamesPlayed": 0,
+    "totalPoints": 0,
+    "currentStreak": 0,
+    "lastPlayedAt": null
+  },
+  "settings": {}
+}
+```
+
+## 5. levelProgress (users/{uid}/levelProgress/{levelId})
+```json
+{
+  "levelId": "multiply-by-2",
+  "bestScore": 10,
+  "bestTimeSeconds": 0,
+  "attempts": 1,
+  "completed": true,
+  "firstCompletedAt": "2025-12-25T12:00:00Z",
+  "lastPlayedAt": "2025-12-25T12:00:00Z"
+}
+```
+
+---
+
+**Note:**
+- Firestore does not enforce a schema – your application must follow it in code.
+- Security rules can require the presence of fields, but cannot enforce the full structure.

--- a/integration_test/auth_service_integration_test.dart
+++ b/integration_test/auth_service_integration_test.dart
@@ -101,20 +101,20 @@ void main() {
     final password = 'TestPassword123!';
     final username = 'RestartUser$timestamp';
 
-    // Rejestracja i logowanie
+    // Register and sign in
     final user = await authService.register(email, password, username);
     expect(user, isNotNull);
 
-    // Symulacja restartu aplikacji (ponowna inicjalizacja AuthService)
+    // Simulate app restart (reinitialize AuthService)
     final newAuthService = AuthService();
 
-    // Oczekujemy, że stream odtworzy zalogowanego użytkownika
+    // We expect the stream to emit the logged-in user
     expect(
       newAuthService.onAuthStateChanged,
       emits(predicate((u) => u is User && u.email == email)),
     );
 
-    // Wylogowanie i ponowna inicjalizacja
+    // Sign out and expect the stream to emit null
     await newAuthService.signOut();
     final afterSignOutAuthService = AuthService();
     expect(afterSignOutAuthService.onAuthStateChanged, emits(null));

--- a/integration_test/auth_service_integration_test.dart
+++ b/integration_test/auth_service_integration_test.dart
@@ -1,18 +1,18 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
 import 'package:projekt_grupowy/services/auth_service.dart';
 import 'package:firebase_core/firebase_core.dart';
 
 void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   late AuthService authService;
 
   setUpAll(() async {
-    // Initialize Firebase only once for all tests
-    TestWidgetsFlutterBinding.ensureInitialized();
     await Firebase.initializeApp();
     authService = AuthService();
   });
 
-  test('register, sign in, and sign out', () async {
+  testWidgets('register, sign in, and sign out (integration)', (WidgetTester tester) async {
     final email = 'testuser${DateTime.now().millisecondsSinceEpoch}@example.com';
     final password = 'TestPassword123!';
     final username = 'TestUser';

--- a/integration_test/auth_service_integration_test.dart
+++ b/integration_test/auth_service_integration_test.dart
@@ -19,7 +19,7 @@ void main() {
     final username = 'TestUser';
 
     // Register
-    final user = await authService.register(email, password, username: username);
+    final user = await authService.register(email, password, username);
     expect(user, isNotNull);
 
     // Sign out
@@ -40,12 +40,12 @@ void main() {
     final username = 'TestUser';
 
     // Register first time
-    final user1 = await authService.register(email, password, username: username);
+    final user1 = await authService.register(email, password, username);
     expect(user1, isNotNull);
 
     // Register second time with same email
     try {
-      await authService.register(email, password, username: username);
+      await authService.register(email, password, username);
       fail('Expected an exception for duplicate email');
     } catch (e) {
       expect(e.toString(), contains('email-already-in-use'));
@@ -59,7 +59,7 @@ void main() {
     final username = 'TestUser';
 
     // Register
-    final user = await authService.register(email, password, username: username);
+    final user = await authService.register(email, password, username);
     expect(user, isNotNull);
 
     // Try to sign in with wrong password
@@ -90,7 +90,7 @@ void main() {
     final username = 'RestartUser';
 
     // Rejestracja i logowanie
-    final user = await authService.register(email, password, username: username);
+    final user = await authService.register(email, password, username);
     expect(user, isNotNull);
 
     // Symulacja restartu aplikacji (ponowna inicjalizacja AuthService)

--- a/integration_test/auth_service_integration_test.dart
+++ b/integration_test/auth_service_integration_test.dart
@@ -32,4 +32,54 @@ void main() {
     // Send password reset (should not throw)
     await authService.sendPasswordReset(email);
   });
+
+  testWidgets('register with existing email should fail', (WidgetTester tester) async {
+    final email = 'duplicateuser${DateTime.now().millisecondsSinceEpoch}@example.com';
+    final password = 'TestPassword123!';
+    final username = 'TestUser';
+
+    // Register first time
+    final user1 = await authService.register(email, password, username: username);
+    expect(user1, isNotNull);
+
+    // Register second time with same email
+    try {
+      await authService.register(email, password, username: username);
+      fail('Expected an exception for duplicate email');
+    } catch (e) {
+      expect(e.toString(), contains('email-already-in-use'));
+    }
+  });
+
+  testWidgets('sign in with wrong password should fail', (WidgetTester tester) async {
+    final email = 'wrongpwuser${DateTime.now().millisecondsSinceEpoch}@example.com';
+    final password = 'TestPassword123!';
+    final wrongPassword = 'WrongPassword!';
+    final username = 'TestUser';
+
+    // Register
+    final user = await authService.register(email, password, username: username);
+    expect(user, isNotNull);
+
+    // Try to sign in with wrong password
+    try {
+      await authService.signIn(email, wrongPassword);
+      fail('Expected an exception for wrong password');
+    } catch (e) {
+      expect(e.toString(), contains('invalid-credential'));
+    }
+  });
+
+  testWidgets('sign in with non-existent email should fail', (WidgetTester tester) async {
+    final email = 'nonexistent${DateTime.now().millisecondsSinceEpoch}@example.com';
+    final password = 'TestPassword123!';
+
+    // Try to sign in with email that was never registered
+    try {
+      await authService.signIn(email, password);
+      fail('Expected an exception for user not found');
+    } catch (e) {
+      expect(e.toString(), contains('invalid-credential'));
+    }
+  });
 }

--- a/integration_test/auth_service_integration_test.dart
+++ b/integration_test/auth_service_integration_test.dart
@@ -14,9 +14,10 @@ void main() {
   });
 
   testWidgets('register, sign in, and sign out (integration)', (WidgetTester tester) async {
-    final email = 'testuser${DateTime.now().millisecondsSinceEpoch}@example.com';
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final email = 'testuser$timestamp@example.com';
     final password = 'TestPassword123!';
-    final username = 'TestUser';
+    final username = 'TestUser$timestamp';
 
     // Register
     final user = await authService.register(email, password, username);
@@ -35,28 +36,31 @@ void main() {
   });
 
   testWidgets('register with existing email should fail', (WidgetTester tester) async {
-    final email = 'duplicateuser${DateTime.now().millisecondsSinceEpoch}@example.com';
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final email = 'duplicateuser$timestamp@example.com';
     final password = 'TestPassword123!';
-    final username = 'TestUser';
+    final username1 = 'TestUser1_$timestamp';
+    final username2 = 'TestUser2_$timestamp';
 
     // Register first time
-    final user1 = await authService.register(email, password, username);
+    final user1 = await authService.register(email, password, username1);
     expect(user1, isNotNull);
 
-    // Register second time with same email
+    // Register second time with same email but different username
     try {
-      await authService.register(email, password, username);
+      await authService.register(email, password, username2);
       fail('Expected an exception for duplicate email');
     } catch (e) {
-      expect(e.toString(), contains('email-already-in-use'));
+      expect(e.toString().toLowerCase(), contains('already in use'));
     }
   });
 
   testWidgets('sign in with wrong password should fail', (WidgetTester tester) async {
-    final email = 'wrongpwuser${DateTime.now().millisecondsSinceEpoch}@example.com';
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final email = 'wrongpwuser$timestamp@example.com';
     final password = 'TestPassword123!';
-    final wrongPassword = 'WrongPassword!';
-    final username = 'TestUser';
+    final wrongPassword = 'WrongPassword1!';
+    final username = 'TestUser$timestamp';
 
     // Register
     final user = await authService.register(email, password, username);
@@ -67,12 +71,16 @@ void main() {
       await authService.signIn(email, wrongPassword);
       fail('Expected an exception for wrong password');
     } catch (e) {
-      expect(e.toString(), contains('invalid-credential'));
+      expect(
+        e.toString().toLowerCase(),
+        anyOf(contains('incorrect'), contains('credential')),
+      );
     }
   });
 
   testWidgets('sign in with non-existent email should fail', (WidgetTester tester) async {
-    final email = 'nonexistent${DateTime.now().millisecondsSinceEpoch}@example.com';
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final email = 'nonexistent$timestamp@example.com';
     final password = 'TestPassword123!';
 
     // Try to sign in with email that was never registered
@@ -80,14 +88,18 @@ void main() {
       await authService.signIn(email, password);
       fail('Expected an exception for user not found');
     } catch (e) {
-      expect(e.toString(), contains('invalid-credential'));
+      expect(
+        e.toString().toLowerCase(),
+        anyOf(contains('incorrect'), contains('credential')),
+      );
     }
   });
 
   testWidgets('onAuthStateChanged restores state after app restart', (WidgetTester tester) async {
-    final email = 'restartuser${DateTime.now().millisecondsSinceEpoch}@example.com';
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final email = 'restartuser$timestamp@example.com';
     final password = 'TestPassword123!';
-    final username = 'RestartUser';
+    final username = 'RestartUser$timestamp';
 
     // Rejestracja i logowanie
     final user = await authService.register(email, password, username);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:firebase_core/firebase_core.dart';
+
 
 import 'widgets/scaffold_with_nav.dart';
 import 'screens/leaderboard_screen.dart';
@@ -20,6 +22,9 @@ void main() async {
 
   // Run tests
   await LocalSaves.testAllClasses();
+
+  // Initialize firebase
+  await Firebase.initializeApp();
 
   runApp(MyApp());
 }

--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -41,3 +41,11 @@ Game engine for the multiple choice mini-game. Players select one of four option
 Handles option shuffling, answer verification, and result generation for integration with session managers. Enforces valid state transitions to prevent illegal operations (e.g., selecting twice).
 
 [Detailed description](../../code_documentation/mc_game_engine_documentation.md)
+
+### `auth_service.dart`
+
+Provides authentication and user management using Firebase Authentication and Firestore.
+- Register, sign in, sign out, password reset
+- Creates user profile documents in Firestore
+
+[Detailed description](../../code_documentation/auth_service.md)

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,55 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class AuthService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  // Sign in with email and password
+  Future<User?> signIn(String email, String password) async {
+    final UserCredential result = await _auth.signInWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+    return result.user;
+  }
+
+  // Register with email, password, and optional username
+  Future<User?> register(String email, String password, {String? username}) async {
+    final UserCredential result = await _auth.createUserWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+    final user = result.user;
+    if (user != null) {
+      // Create user document in Firestore
+      await _firestore.collection('users').doc(user.uid).set({
+        'profile': {
+          'displayName': username ?? '',
+          'age': null,
+        },
+        'stats': {
+          'totalGamesPlayed': 0,
+          'totalPoints': 0,
+          'currentStreak': 0,
+          'lastPlayedAt': null,
+        },
+        'settings': {},
+      });
+    }
+    return user;
+  }
+
+  // Send password reset email
+  Future<void> sendPasswordReset(String email) async {
+    await _auth.sendPasswordResetEmail(email: email);
+  }
+
+  // Sign out
+  Future<void> signOut() async {
+    await _auth.signOut();
+  }
+
+  // Stream of auth state changes
+  Stream<User?> get onAuthStateChanged => _auth.authStateChanges();
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -110,6 +110,29 @@ class AuthService {
       throw Exception('An unknown error occurred.');
     }
   }
+  
+  // Sign in with email and password
+  Future<User?> signIn(String email, String password) async {
+    if (email.isEmpty || !_isValidEmail(email)) {
+      throw Exception('Please enter a valid email address.');
+    }
+    if (!_isValidPassword(password)) {
+      throw Exception('Password must be at least 8 characters long and include uppercase, lowercase, number, and special character.');
+    }
+    try {
+      final UserCredential result = await _auth.signInWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      return result.user;
+    } on FirebaseAuthException catch (e) {
+      throw Exception(e.message ?? 'Authentication error.');
+    } on FirebaseException catch (e) {
+      throw Exception(e.message ?? 'Firebase error.');
+    } catch (e) {
+      throw Exception('An unknown error occurred.');
+    }
+  }
 
   // Sign out
   Future<void> signOut() async {

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -5,13 +5,37 @@ class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
-    bool _isValidEmail(String email) {
-    final emailRegex = RegExp(r"^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}");
+  // Checks if the email format is valid (simple version)
+  bool _isValidEmail(String email) {
+    final emailRegex = RegExp(r'^\S+@\S+\.\S+$');
+    // Regex explanation:
+    // r                : raw string
+    // ^                : start of string
+    // \S+              : one or more non-whitespace characters
+    // @                : literal @
+    // \S+              : one or more non-whitespace characters
+    // \.               : literal dot
+    // \S+              : one or more non-whitespace characters
+    // $                : end of string
     return emailRegex.hasMatch(email);
   }
 
+  // Deprecated: fetchSignInMethodsForEmail is no longer supported due to security reasons.
+  // Instead, handle 'email-already-in-use' error in register method.
+
+  
   bool _isValidPassword(String password) {
-    return password.length >= 6;
+    final passwordRegex = RegExp(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#\$%\^&\*\-_\+=\[\]{};:\\|,.<>\/?]).{8,}$');
+    // Regex explanation:
+    // r                : raw string 
+    // ^                : start of string
+    // (?=.*[a-z])      : at least one lowercase letter
+    // (?=.*[A-Z])      : at least one uppercase letter
+    // (?=.*\d)         : at least one digit
+    // (?=.*[!@#\$%\^&\*\-_\+=\[\]{};:\\|,.<>\/?]) : at least one special character
+    // .{8,}            : at least 8 characters long
+    // $                : end of string
+    return passwordRegex.hasMatch(password);
   }
 
   bool _isValidUsername(String username) {
@@ -23,50 +47,81 @@ class AuthService {
     return query.docs.isNotEmpty;
   }
 
-  // Sign in with email and password
-  Future<User?> signIn(String email, String password) async {
-    final UserCredential result = await _auth.signInWithEmailAndPassword(
-      email: email,
-      password: password,
-    );
-    return result.user;
-  }
-
-  // Register with email, password, and optional username
+  // Register with email, password, and username
   Future<User?> register(String email, String password, String username) async {
-    final UserCredential result = await _auth.createUserWithEmailAndPassword(
-      email: email,
-      password: password,
-      username: username,
-    );
-    final user = result.user;
-    if (user != null) {
-      // Create user document in Firestore
-      await _firestore.collection('users').doc(user.uid).set({
-        'profile': {
-          'displayName': username,
-          'age': null,
-        },
-        'stats': {
-          'totalGamesPlayed': 0,
-          'totalPoints': 0,
-          'currentStreak': 0,
-          'lastPlayedAt': null,
-        },
-        'settings': {},
-      });
+    if (email.isEmpty || !_isValidEmail(email)) {
+      throw Exception('Please enter a valid email address.');
     }
-    return user;
+    if (!_isValidPassword(password)) {
+      throw Exception('Password must be at least 8 characters long and include uppercase, lowercase, number, and special character.');
+    }
+    if (!_isValidUsername(username)) {
+      throw Exception('Please enter a valid username.');
+    }
+    if (await _isUsernameTaken(username)) {
+      throw Exception('This username is already taken.');
+    }
+    try {
+      final UserCredential result = await _auth.createUserWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      final user = result.user;
+      if (user != null) {
+        // Create user document in Firestore
+        await _firestore.collection('users').doc(user.uid).set({
+          'profile': {
+            'displayName': username,
+            'age': null,
+          },
+          'stats': {
+            'totalGamesPlayed': 0,
+            'totalPoints': 0,
+            'currentStreak': 0,
+            'lastPlayedAt': null,
+          },
+          'settings': {},
+        });
+      }
+      return user;
+    } on FirebaseAuthException catch (e) {
+      // If the email is already in use, Firebase throws a FirebaseAuthException with code 'email-already-in-use'.
+      // This is handled here and a user-friendly message can be provided if needed.
+      throw Exception(e.message ?? 'Registration error.');
+    } on FirebaseException catch (e) {
+      throw Exception(e.message ?? 'Firebase error.');
+    } catch (e) {
+      throw Exception('An unknown error occurred.');
+    }
   }
 
   // Send password reset email
   Future<void> sendPasswordReset(String email) async {
-    await _auth.sendPasswordResetEmail(email: email);
+    if (email.isEmpty || !_isValidEmail(email)) {
+      throw Exception('Please enter a valid email address.');
+    }
+    try {
+      await _auth.sendPasswordResetEmail(email: email);
+    } on FirebaseAuthException catch (e) {
+      throw Exception(e.message ?? 'Password reset error.');
+    } on FirebaseException catch (e) {
+      throw Exception(e.message ?? 'Firebase error.');
+    } catch (e) {
+      throw Exception('An unknown error occurred.');
+    }
   }
 
   // Sign out
   Future<void> signOut() async {
-    await _auth.signOut();
+    try {
+      await _auth.signOut();
+    } on FirebaseAuthException catch (e) {
+      throw Exception(e.message ?? 'Sign out error.');
+    } on FirebaseException catch (e) {
+      throw Exception(e.message ?? 'Firebase error.');
+    } catch (e) {
+      throw Exception('An unknown error occurred.');
+    }
   }
 
   // Stream of auth state changes

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -286,6 +286,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -312,6 +317,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -384,6 +394,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -576,6 +591,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -725,6 +748,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -813,6 +844,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "67.0.0"
+  _flutterfire_internals:
+    dependency: transitive
+    description:
+      name: _flutterfire_internals
+      sha256: e4a1b612fd2955908e26116075b3a4baf10c353418ca645b4deae231c82bf144
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.65"
   analyzer:
     dependency: transitive
     description:
@@ -129,6 +137,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  cloud_firestore:
+    dependency: "direct main"
+    description:
+      name: cloud_firestore
+      sha256: "88abd6dc7786c23c8b5e434901bb0d79176414e52e9ab50a8e52552ff6148d7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.1"
+  cloud_firestore_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_firestore_platform_interface
+      sha256: "573d4b4ebc56ba573dc9bac88b65bdb991cc5b66a885a62c7ab8dd1e2eaa0944"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.5"
+  cloud_firestore_web:
+    dependency: transitive
+    description:
+      name: cloud_firestore_web
+      sha256: c1ef53308a09d475503f75b658b65fae32af24047d03bba0713098f882ed187f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
   code_builder:
     dependency: transitive
     description:
@@ -193,14 +225,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  firebase_auth:
+    dependency: "direct main"
+    description:
+      name: firebase_auth
+      sha256: "060a9bfc9877538dfdc69f2fdc1e0bf068439a7e9f22da6513f7b9bde308bb93"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.3"
+  firebase_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_auth_platform_interface
+      sha256: e91c9aadf9944e8319855fa752fd6c664bade2bbd6e7697a5142113c319a4288
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.5"
+  firebase_auth_web:
+    dependency: transitive
+    description:
+      name: firebase_auth_web
+      sha256: "155145fd84f311e50eb2bfeb892f74b0d1b30936f40765a051b70110270cb6d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.1"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "132e1c311bc41e7d387b575df0aacdf24efbf4930365eb61042be5bde3978f03"
+      sha256: "29cfa93c771d8105484acac340b5ea0835be371672c91405a300303986f4eba9"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -213,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: ecde2def458292404a4fcd3731ee4992fd631a0ec359d2d67c33baa8da5ec8ae
+      sha256: a631bbfbfa26963d68046aed949df80b228964020e9155b086eff94f462bbf1f
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.1"
   fixnum:
     dependency: transitive
     description:
@@ -304,6 +360,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,8 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   hive_generator: ^2.0.1
   build_runner: ^2.4.7
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
   firebase_core: ^4.2.0
+  firebase_auth: ^6.1.3
+  cloud_firestore: ^6.1.1
   go_router: ^17.0.0
   hive: ^2.2.3
   hive_flutter: ^1.1.0

--- a/test/services/auth_service_test.dart
+++ b/test/services/auth_service_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:projekt_grupowy/services/auth_service.dart';
+import 'package:firebase_core/firebase_core.dart';
+
+void main() {
+  late AuthService authService;
+
+  setUpAll(() async {
+    // Initialize Firebase only once for all tests
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await Firebase.initializeApp();
+    authService = AuthService();
+  });
+
+  test('register, sign in, and sign out', () async {
+    final email = 'testuser${DateTime.now().millisecondsSinceEpoch}@example.com';
+    final password = 'TestPassword123!';
+    final username = 'TestUser';
+
+    // Register
+    final user = await authService.register(email, password, username: username);
+    expect(user, isNotNull);
+
+    // Sign out
+    await authService.signOut();
+    expect(authService.onAuthStateChanged, emits(null));
+
+    // Sign in
+    final signInUser = await authService.signIn(email, password);
+    expect(signInUser, isNotNull);
+
+    // Send password reset (should not throw)
+    await authService.sendPasswordReset(email);
+  });
+}


### PR DESCRIPTION
Closes #46 

I didn't do anything about this part:

- Hive może przechowywać:
    - lastKnownUserId (identyfikacja cache’u),
    - dane należące do ostatniej sesji (profil, wyniki, postęp), ale nie decyduje o routingu ani auth.
    ale NIE służy do:
        - odtwarzania stanu zalogowania,
        - podejmowania decyzji auth lub routingu.

but I think it should be done with #47 issue, not this one since it only covers authentication